### PR TITLE
Chore: Downgrade to `types-docutils==0.20.0.3` to fix mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,11 @@ dependencies = [
 [project.optional-dependencies]
 develop = [
   "black<24",
-  "docutils-stubs",
   "mypy==1.8.0",
   "poethepoet<0.25",
   "pyproject-fmt<1.8",
   "ruff==0.1.14",
+  "types-docutils==0.20.0.3",
   "validate-pyproject<0.17",
 ]
 docs = [


### PR DESCRIPTION
What the title says.