### PR TITLE
Add `hyper` role, to render hyperlinks with style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Accept more options on grid table's `sd-item` directive
 - Add `shield` directive, to render badges through Shields.io
+- Add `hyper` role, to render different kinds of hyperlinks
 
 ## v0.2.1 - 2023-08-08
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: auto    # the required coverage value
+        threshold: 3%   # the leniency in hitting the target
+
+    patch:
+      default:
+        target: auto    # the required coverage value
+        threshold: 3%   # the leniency in hitting the target

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,3 +8,10 @@ orphan: true
 - From `sphinx-design` 
   - horizontal card (grid row inside card, picture on left)
   - subtitle for card (see <https://material.io/components/cards#anatomy>)
+- hyper: Maintain a synthetic intersphinx inventory for caching titles from
+  extracted HTML pages, so that subsequent invocations do not need to
+  extract titles over and over again.
+- shield: Derive fundamental implementation from [sphinx_toolbox.shields]?
+
+
+[sphinx_toolbox.shields]: https://github.com/sphinx-toolbox/sphinx-toolbox/blob/master/sphinx_toolbox/shields.py

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -12,6 +12,7 @@ orphan: true
   extracted HTML pages, so that subsequent invocations do not need to
   extract titles over and over again.
 - shield: Derive fundamental implementation from [sphinx_toolbox.shields]?
+- https://chrisholdgraf.com/blog/2023/social-directive/
 
 
 [sphinx_toolbox.shields]: https://github.com/sphinx-toolbox/sphinx-toolbox/blob/master/sphinx_toolbox/shields.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ extensions = [
     "sphinx_design",
     "sphinx_design_elements",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
 ]
 
 html_theme = os.environ.get("SPHINX_THEME", "furo")
@@ -61,3 +62,5 @@ intersphinx_mapping = {
     "sd": ("https://sphinx-design.readthedocs.io/en/latest/", None),
     "myst": ("https://myst-parser.readthedocs.io/en/latest/", None),
 }
+
+todo_include_todos = True

--- a/docs/hyper.md
+++ b/docs/hyper.md
@@ -1,0 +1,580 @@
+(hyper-role)=
+
+# Hyper
+
+
+## About
+
+A component to render hyperlinks with a few bells and whistles,
+implementing the Sphinx role `hyper`.
+
+
+## Features
+
+The `hyper` role aims to expand the features of the traditional
+Sphinx `:ref:` / `{ref}` role everyone loves so much for its powerful
+linking capabilities.
+
+:Syntax Extension:
+    The standard role expression syntax of `{ref}` is extended, by adding a
+    third slot for conveying additional **options** to Sphinx roles, building
+    upon fundamentals of Sphinx referencing and linking. A typical markup
+    snippet using the `{hyper}` role in MyST syntax looks like this.
+    :::{code}
+    {hyper}`label <resource> {option1=value1,option2=value2}`
+    :::
+    The most basic variant is to just slap an arbitrary resource identifier
+    into its value slot. That can be a Sphinx reference of any kind, or just
+    an URL.
+    :::{code}
+    {hyper}`resource`
+    :::
+
+:Referencing and Linking:
+    The role implementation `HyperRefRole` inherits all the niceties from
+    `AnyXRefRole`. 
+    Linking features are enhanced by providing rST / MyST cross-over
+    compatibility, and a few other gimmicks like automatically deriving
+    link labels from `<title>` elements of HTML pages on arbitrary URLs.
+
+:Layout and Style:
+    Other than rendering plain HTML hyperlink anchors, the `hyper` role
+    provides an array of options to present hyperlinks differently.
+    For example, hyperlinks can be represented through badges from
+    [Shields.io], building upon the {ref}`shield <shield-directive>`
+    directive, just by slapping a `{type=shield}` option on it.
+
+
+## Synopsis
+
+A hyperlink that navigates to a URL, rendered in different variants,
+defined using the markup outlined below.
+
+::::{card}
+
+:Text-Only:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+
+:Shield:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
+
+::::
+
+
+
+## Usage
+
+::::{tab-set-code}
+:::{literalinclude} ./snippets/myst/hyper.md
+:language: markdown
+:::
+::::
+
+:::{warning}
+Currently only works with MyST.
+reStructuredText is not supported yet, but support can be added.
+:::
+
+The `hyper` role provides a few configuration options, 
+mimicking and expanding `{ref}`.
+
+:::::::{sd-table}
+:widths: 3 9
+:row-class: col-compact
+
+:::{rubric} Fundamentals
+:::
+
+::::::{sd-row}
+:::::{sd-item} **Item**
+:::::
+:::::{sd-item} **Description and Syntax**
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org` \
+{hyper}`mailto:test@example.org`
+:::::
+:::::{sd-item}
+A basic hyper without any options, referencing an URL.
+::::{code} markdown
+
+{hyper}`https://example.org` \
+{hyper}`mailto:test@example.org`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`Read More <https://example.org>`
+:::::
+:::::{sd-item}
+Referencing a URL with a self-defined link label.
+::::{code} markdown
+
+{hyper}`Read More <https://example.org>`
+::::
+:::::
+::::::
+
+
+:::{rubric} Linking and Referencing
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`infocard-directive` \
+{hyper}`#infocard-directive`
+:::::
+:::::{sd-item}
+Links to project-local references can be defined by using reference labels
+in both reStructuredText and MyST syntax.
+::::{code} markdown
+
+{hyper}`infocard-directive` \
+{hyper}`#infocard-directive`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`sd:sd-cards` \
+{hyper}`Card Layouts <sd:sd-cards>`
+:::::
+:::::{sd-item}
+Using a traditional intersphinx reference is the most compact way to
+run links to other Sphinx projects.
+::::{code} markdown
+
+{hyper}`sd:sd-cards` \
+{hyper}`Card Layouts <sd:sd-cards>`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`inv:sd:*:doc#index` \
+{hyper}`inv:sd:*:label#sd-grids` \
+{hyper}`inv:sd#sd-cards`
+:::::
+:::::{sd-item}
+MyST reference syntax is also supported for intersphinx links.
+::::{code} markdown
+
+{hyper}`inv:sd:*:doc#index` \
+{hyper}`inv:sd:*:label#sd-grids` \
+{hyper}`inv:sd#sd-cards`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`Grid Table <[gridtable]>` \
+{hyper}`Sphinx Design <[sphinx-design]>` \
+{hyper}`Example Domain <[example-org]>`
+
+[gridtable]: gridtable-directive
+[sphinx-design]: inv:sd#index
+[example-org]: https://example.org/
+:::::
+:::::{sd-item}
+Indirect references are defined out-of-band from the link definition, for example
+at the end of the page.
+
+In MyST, indirect references are defined by, for example:
+- `[label]: <reference>`
+- `[label]: #<reference>`
+- `[label]: inv:<project>#<reference>`
+- `[label]: <url>`
+:::{div} text-small
+**Note:** This only works in MyST.
+:::
+::::{code} markdown
+
+{hyper}`Grid Table <[gridtable]>` \
+{hyper}`Sphinx Design <[sphinx-design]>` \
+{hyper}`Example Domain <[example-org]>`
+
+[gridtable]: gridtable-directive
+[sphinx-design]: inv:sd#index
+[example-org]: https://example.org/
+::::
+:::::
+::::::
+
+:::::::
+
+
+## Variants
+
+The `hyper` role provides a few rendering variants.
+
+:::::::{sd-table}
+:widths: 3 9
+:row-class: col-compact
+
+:::{rubric} Shield
+:::
+
+Adding the option `{type=shield}` renders the hyperlink using a badge based
+on the [`shield`](#shield-directive) directive implementation.
+
+::::::{sd-row}
+:::::{sd-item} **Item**
+:::::
+:::::{sd-item} **Description and Syntax**
+:::::
+::::::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield}` \
+{hyper}`mailto:test@example.org {type=shield}`
+:::::
+:::::{sd-item}
+A basic shield hyperlink.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield}` \
+{hyper}`mailto:test@example.org {type=shield}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`Read More <https://example.org> {type=shield}`
+:::::
+:::::{sd-item}
+Using a self-defined linked label works the same way with `{type=shield}`.
+::::{code} markdown
+
+{hyper}`Read More <https://example.org> {type=shield}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`Info Card <infocard-directive> {type=shield}` \
+{hyper}`Info Card <#infocard-directive> {type=shield}`
+:::::
+:::::{sd-item}
+Link to project-local references, with link labels.
+::::{code} markdown
+
+{hyper}`Info Card <infocard-directive> {type=shield}` \
+{hyper}`Info Card <#infocard-directive> {type=shield}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`sd:sd-cards {type=shield}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=shield}`
+:::::
+:::::{sd-item}
+Using a traditional intersphinx reference is the most compact way to
+run links to other Sphinx projects.
+::::{code} markdown
+
+{hyper}`sd:sd-cards {type=shield}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=shield}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`inv:sd:*:doc#index {type=shield}` \
+{hyper}`inv:sd:*:label#sd-grids {type=shield}` \
+{hyper}`inv:sd#sd-cards {type=shield}`
+:::::
+:::::{sd-item}
+MyST reference syntax is also supported for intersphinx links.
+::::{code} markdown
+
+{hyper}`inv:sd:*:doc#index {type=shield}` \
+{hyper}`inv:sd:*:label#sd-grids {type=shield}` \
+{hyper}`inv:sd#sd-cards {type=shield}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield,label=Read}`
+:::::
+:::::{sd-item}
+A shield with an additional label, rendered on the left-hand side.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,label=Read}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`More <https://example.org> {type=shield,label=Read}` \
+{hyper}`https://example.org {type=shield,label=Read,message=More}`
+:::::
+:::::{sd-item}
+When using an additional shield `label` on the left-hand side, the
+text on the right-hand side can be defined through the link label,
+or the `message` option. 
+::::{code} markdown
+
+{hyper}`More <https://example.org> {type=shield,label=Read}` \
+{hyper}`https://example.org {type=shield,label=Read,message=More}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
+:::::
+:::::{sd-item}
+Text input also accepts Unicode glyphs.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`H1 <https://example.org> {type=shield}`
+{hyper}`H2 <https://example.org> {type=shield}`
+:::::
+:::::{sd-item}
+By default, `hyper` roles render as inline elements, so multiple ones are
+placed side by side, even when authored using line breaks.
+::::{code} markdown
+
+{hyper}`H1 <https://example.org> {type=shield}`
+{hyper}`H2 <https://example.org> {type=shield}`
+::::
+:::{tip}
+For purposely applying line breaks, use the backslash `\` as line
+continuation character.
+:::
+:::::
+::::::
+
+
+:::{rubric} Styling
+:::
+
+About defining colors, an icon, and the style/shape of the shield.
+The corresponding options accept the same values like the
+[`shield`](#shield-directive) directive.
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield,color=darkgreen}`
+:::::
+:::::{sd-item}
+Use the [`color`](#shield-color) option to adjust the background color.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,color=darkgreen,logo=Markdown}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield,label=Read,message=More,label-color=darkgreen,message-color=orange}` \
+{hyper}`https://example.org {type=shield,label=Read,message=More,label-color=hsl(270,60%,70%),message-color=rgb(255,0,153)}` \
+{hyper}`https://example.org {type=shield,message=Read More,color=#123456}`
+:::::
+:::::{sd-item}
+Left vs. right background colors can be defined by using the `label-color`
+vs. `message-color` options, see [](#shield-color). For single-colored shields,
+the `color` option can be used as an alias for `message-color`.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,label=Read,message=More,label-color=darkgreen,message-color=orange}` \
+{hyper}`https://example.org {type=shield,label=Read,message=More,label-color=hsl(270,60%,70%),message-color=rgb(255,0,153)}` \
+{hyper}`https://example.org {type=shield,message=Read More,color=#123456}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`CrateDB <https://cratedb.com> {type=shield,color=gray,logo=CrateDB}`
+:::::
+:::::{sd-item}
+Select an image from a collection of brand depictions, using the
+[`logo`](#shield-logo) option.
+::::{code} markdown
+
+{hyper}`CrateDB <https://cratedb.com> {type=shield,color=gray,logo=CrateDB}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=shield,style=flat}` \
+{hyper}`https://example.org {type=shield,style=flat-square}` \
+{hyper}`https://example.org {type=shield,style=plastic}` \
+{hyper}`https://example.org {type=shield,style=for-the-badge}` \
+{hyper}`https://example.org {type=shield,style=social}`
+:::::
+:::::{sd-item}
+The [`style`](#shield-style) option determines the style / shape of the shield.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,style=flat}` \
+{hyper}`https://example.org {type=shield,style=flat-square}` \
+{hyper}`https://example.org {type=shield,style=plastic}` \
+{hyper}`https://example.org {type=shield,style=for-the-badge}` \
+{hyper}`https://example.org {type=shield,style=social}`
+::::
+:::::
+::::::
+
+
+:::::::
+
+
+## Gallery
+
+A few more examples, about shortcuts and intersphinx linking.
+
+::::{dropdown} Shortcuts
+:animate: fade-in-slide-down
+:open:
+
+Shortcut roles help saving keystrokes. Examples:
+`hyper-navigate`, `hyper-open`, `hyper-tutorial`, `hyper-read-more`,
+`hyper-readme-github`, `hyper-nb-colab`, `hyper-nb-binder`, `hyper-nb-github`. 
+
+---
+
+{hyper-navigate}`https://example.org`
+{hyper-open}`https://example.org`
+
+{hyper-tutorial}`https://example.org`
+{hyper-read-more}`https://example.org`
+{hyper-readme-github}`https://example.org`
+
+{hyper-nb-colab}`https://example.org`
+{hyper-nb-binder}`https://example.org`
+{hyper-nb-github}`https://example.org`
+
+::::{code} markdown
+
+{hyper-navigate}`https://example.org`
+{hyper-open}`https://example.org`
+
+{hyper-tutorial}`https://example.org`
+{hyper-read-more}`https://example.org`
+{hyper-readme-github}`https://example.org`
+
+{hyper-nb-colab}`https://example.org`
+{hyper-nb-binder}`https://example.org`
+{hyper-nb-github}`https://example.org`
+::::
+
+::::{dropdown} Intersphinx across the board
+:animate: fade-in-slide-down
+
+There are some flaws here yet, see backlog below.
+
+:::{rubric} Intersphinx Text-Only
+:::
+
+- {hyper }`sd:index` provides
+{hyper}`sd:sd-grids`
+{hyper}`sd:sd-cards`
+{hyper}`sd:sd-dropdowns`
+{hyper}`sd:sd-tabs`
+{hyper }`sd:badges_buttons`
+{hyper }`doc:badges_buttons`
+{hyper}`sd:special`.
+
+
+:::{rubric} Intersphinx Shields
+:::
+
+- {hyper}`sd:index {type=shield}` provides
+{hyper}`sd:sd-grids {type=shield}`
+{hyper}`sd:sd-cards {type=shield}`
+{hyper}`sd:sd-dropdowns {type=shield}`
+{hyper}`sd:sd-tabs {type=shield}`
+{hyper}`sd:badges_buttons {type=shield}`
+{hyper}`sd:special {type=shield}`.
+
+- {hyper}`myst:index {type=shield}` provides
+{hyper}`myst:syntax/core {type=shield}`
+{hyper}`myst:syntax/colon_fence {type=shield}`
+{ hyper}`myst:syntax/admonitions {type=shield}`
+{hyper}`myst:syntax/images_and_figures {type=shield}`
+{hyper}`myst:syntax/roles-and-directives {type=shield}`
+{hyper}`myst:syntax/reference {type=shield}`
+{hyper}`myst:syntax/cross-referencing {type=shield}`
+{hyper}`myst:syntax/code_and_apis {type=shield}`
+{ hyper}`myst:syntax/math {type=shield}`
+{hyper}`myst:syntax/extensions {type=shield}`.
+
+::::
+
+
+## Backlog
+
+:::{todo}
+There are a few errors in here: `sd:index`, `sd:badges_buttons`, and
+`doc:badges_buttons` can't be resolved well.
+:::
+:::{todo}
+Link label resolution does not work yet with project-local links, e.g.
+{hyper}`infocard-directive`, {hyper}`#infocard-directive`.
+:::
+:::{todo}
+rgb() / hsl() colors do not work, yet. They contain values separated by
+commas, which confuses the naive role option parser.
+:::
+:::{todo}
+Resolving `myst:syntax/admonitions` and `myst:syntax/math` does not work yet,
+due to ambiguity errors.
+
+-- [More than one target found for 'myst' cross-reference [myst.xref_ambiguous]](https://github.com/executablebooks/MyST-Parser/issues/892)
+:::
+:::{todo}
+Maybe use a different way of having shortcuts, not by using dedicated roles,
+but integrated into the options instead. Also, leverage shield-level style
+presets, as outlined in their backlog.
+:::
+
+
+[Shields.io]: https://shields.io/

--- a/docs/hyper.md
+++ b/docs/hyper.md
@@ -42,6 +42,11 @@ linking capabilities.
     provides an array of options to present hyperlinks differently. Hyper
     currently supports:
 
+    :::{rubric} Badge
+    :::
+    The {ref}`hyper-badge` Hyper renders hyperlinks using the
+    {ref}`bdg-* <sd:badges>` roles from [](inv:sd#index).
+
     :::{rubric} Button
     :::
     The {ref}`hyper-button` Hyper renders hyperlinks using the
@@ -61,14 +66,17 @@ defined using the markup outlined below.
 
 ::::{card}
 
-:Text:
-    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+:Badge:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=badge,outline=true,short-title=true}`
 
 :Button:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
 
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
+
+:Text:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
 
 ::::
 
@@ -87,15 +95,15 @@ Currently only works with MyST.
 reStructuredText is not supported yet, but support can be added.
 :::
 
+(hyper-basics)=
+:::{rubric} Fundamentals
+:::
 The `hyper` role provides a few configuration options, 
 mimicking and expanding `{ref}`.
 
 :::::::{sd-table}
 :widths: 3 9
 :row-class: col-compact bottom-margin-generous
-
-:::{rubric} Fundamentals
-:::
 
 ::::::{sd-row}
 :::::{sd-item} **Item**
@@ -233,12 +241,171 @@ In MyST, indirect references are defined by, for example:
 The `hyper` role provides a few rendering variants.
 
 
+(hyper-badge)=
+### Badge
+
+Adding the option `{type=badge}` renders the hyperlink using a badge based
+on the sphinx-design [`bdg-*`](inv:sd#badges) roles.
+
+:::{rubric} Options
+:::
+
+color
+: Set the color of the button (background and font).
+  One of the semantic color names: `primary`, `secondary`, `success`, `danger`,
+  `warning`, `info`, `light`, `dark`, `muted`.
+  The default value is `primary`.
+
+outline
+: Display button in outlined color style variant. Use `outline=true`
+  to toggle that option.
+
+
+:::{rubric} Fundamentals
+:::
+
+:::::::{sd-table}
+:widths: 3 9
+:row-class: col-compact bottom-margin-generous
+
+::::::{sd-row}
+:::::{sd-item} **Item**
+:::::
+:::::{sd-item} **Description and Syntax**
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=badge}`
+:::::
+:::::{sd-item}
+A basic badge hyperlink for URLs, without any options.
+::::{code} markdown
+
+{hyper}`https://example.org {type=badge}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`shield-directive {type=badge}` \
+{hyper}`Shield badges <shield-directive> {type=badge}`
+:::::
+:::::{sd-item}
+Use project-local references.
+::::{code} markdown
+
+{hyper}`shield-directive {type=badge}` \
+{hyper}`Shield badges <shield-directive> {type=badge}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`sd:sd-cards {type=badge}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=badge}`
+:::::
+:::::{sd-item}
+Use intersphinx references.
+::::{code} markdown
+
+{hyper}`sd:sd-cards {type=badge}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=badge}`
+::::
+:::::
+::::::
+
+
+:::{rubric} Layout
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`1 <https://example.org> {type=badge,outline=true}`
+{hyper}`2 <https://example.org> {type=badge,outline=true}`
+{hyper}`3 <https://example.org> {type=badge,outline=true}`
+:::::
+:::::{sd-item}
+Because `hyper` roles render as inline elements, like `bdg-*` badges,
+multiple instances can be placed side by side, even when written down
+spanning multiple lines.
+::::{code} markdown
+
+{hyper}`1 <https://example.org> {type=badge,outline=true}`
+{hyper}`2 <https://example.org> {type=badge,outline=true}`
+{hyper}`3 <https://example.org> {type=badge,outline=true}`
+::::
+:::{tip}
+For purposely applying line breaks, use the backslash `\` as line
+continuation character.
+:::
+:::::
+::::::
+
+
+:::{rubric} Style
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=badge,color=info}`
+:::::
+:::::{sd-item}
+The `color` option determines the color.
+::::{code} markdown
+
+{hyper}`https://example.org {type=badge,color=info}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=badge,outline=true}`
+:::::
+:::::{sd-item}
+The `outline` option draws the badge in a different style.
+::::{code} markdown
+
+{hyper}`https://example.org {type=badge,outline=true}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`🌻 Read More 🍀 <https://example.org> {type=badge,outline=true}`
+:::::
+:::::{sd-item}
+Text input accepts Unicode glyphs.
+::::{code} markdown
+
+{hyper}`🌻 Read More 🍀 <https://example.org> {type=badge,outline=true}`
+::::
+:::::
+::::::
+
+
+:::::::
+
+
 (hyper-button)=
 ### Button
 
-Adding the option `{type=button}` renders the hyperlink using a badge based
-on the sphinx-design [`button`](inv:sd#buttons) directive implementation, it
+Adding the option `{type=button}` renders the hyperlink using a button based
+on the sphinx-design [`button`](inv:sd#buttons) directive, it
 accepts the same options, and the additional `icon` option.
+
+:::{rubric} Options
+:::
 
 ref-type (`button-ref` only)
 : Type of reference to use; `any` (default), `ref`, `doc`, or `myst`
@@ -282,6 +449,9 @@ shadow
 class
 : Additional CSS classes.
 
+
+:::{rubric} Fundamentals
+:::
 
 :::::::{sd-table}
 :widths: 3 9
@@ -398,6 +568,10 @@ line breaks.
 {hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
 {hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
 ::::
+:::{tip}
+For purposely applying line breaks, use the backslash `\` as line
+continuation character.
+:::
 :::::
 ::::::
 
@@ -445,6 +619,20 @@ Use `class` and `tooltip` options.
 
 ::::::{sd-row}
 :::::{sd-item}
+{hyper}`🌻 Read More 🍀 <https://example.org> {type=button}`
+:::::
+:::::{sd-item}
+Text input accepts Unicode glyphs.
+::::{code} markdown
+
+{hyper}`🌻 Read More 🍀 <https://example.org> {type=button}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
 {hyper}`Read More <https://example.org> {type=button,icon=octicon:report}` \
 {hyper}`Read More <https://example.org> {type=button,color=info,outline=true,icon=material-outlined:emoji_objects;3em;sd-text-primary}`
 :::::
@@ -468,6 +656,17 @@ The value of the `icon` option translates to the syntax of an {ref}`inline icon
 
 Adding the option `{type=shield}` renders the hyperlink using a badge based
 on the [`shield`](#shield-directive) directive implementation.
+
+
+:::{rubric} Options
+:::
+
+Please refer to the corresponding [`shield` options](#shield-options), in order
+to learn about how this component can be configured.
+
+
+:::{rubric} Fundamentals
+:::
 
 :::::::{sd-table}
 :widths: 3 9
@@ -598,30 +797,18 @@ or the `message` option.
 
 ::::::{sd-row}
 :::::{sd-item}
-{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
-:::::
-:::::{sd-item}
-Text input also accepts Unicode glyphs.
-::::{code} markdown
-
-{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
-::::
-:::::
-::::::
-
-
-::::::{sd-row}
-:::::{sd-item}
-{hyper}`H1 <https://example.org> {type=shield}`
-{hyper}`H2 <https://example.org> {type=shield}`
+{hyper}`1 <https://example.org> {type=shield}`
+{hyper}`2 <https://example.org> {type=shield}`
+{hyper}`3 <https://example.org> {type=shield}`
 :::::
 :::::{sd-item}
 Because `hyper` roles render as inline elements, multiple instances can
 be placed side by side, even when written down spanning multiple lines.
 ::::{code} markdown
 
-{hyper}`H1 <https://example.org> {type=shield}`
-{hyper}`H2 <https://example.org> {type=shield}`
+{hyper}`1 <https://example.org> {type=shield}`
+{hyper}`2 <https://example.org> {type=shield}`
+{hyper}`3 <https://example.org> {type=shield}`
 ::::
 :::{tip}
 For purposely applying line breaks, use the backslash `\` as line
@@ -675,6 +862,20 @@ the `color` option can be used as an alias for `message-color`.
 
 ::::::{sd-row}
 :::::{sd-item}
+{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
+:::::
+:::::{sd-item}
+Text input accepts Unicode glyphs.
+::::{code} markdown
+
+{hyper}`https://example.org {type=shield,label=🌻 Read,message=More 🍀}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
 {hyper}`CrateDB <https://cratedb.com> {type=shield,color=gray,logo=CrateDB}`
 :::::
 :::::{sd-item}
@@ -712,10 +913,121 @@ The [`style`](#shield-style) option determines the style / shape of the shield.
 :::::::
 
 
+(hyper-text)=
+### Text
+
+The textual output variant and its features are outlined at the
+[](hyper-basics) section.
+
 
 ## Gallery
 
 A few more examples, about shortcuts and intersphinx linking.
+
+
+::::{dropdown} Badges Everywhere
+:animate: fade-in-slide-down
+:open:
+
+Badges in multiple colors, optionally outlined.
+
+{hyper}`primary <https://example.org> {type=badge,color=primary}`
+{hyper}`secondary <https://example.org> {type=badge,color=secondary}`
+{hyper}`success <https://example.org> {type=badge,color=success}`
+{hyper}`danger <https://example.org> {type=badge,color=danger}`
+{hyper}`warning <https://example.org> {type=badge,color=warning}`
+{hyper}`info <https://example.org> {type=badge,color=info}`
+{hyper}`light <https://example.org> {type=badge,color=light}`
+{hyper}`dark <https://example.org> {type=badge,color=dark}`
+{hyper}`muted <https://example.org> {type=badge,color=muted}`
+
+{hyper}`primary <https://example.org> {type=badge,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=badge,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=badge,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=badge,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=badge,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=badge,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=badge,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=badge,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=badge,color=muted,outline=true}`
+
+:::{code} markdown
+
+{hyper}`primary <https://example.org> {type=badge,color=primary}`
+{hyper}`secondary <https://example.org> {type=badge,color=secondary}`
+{hyper}`success <https://example.org> {type=badge,color=success}`
+{hyper}`danger <https://example.org> {type=badge,color=danger}`
+{hyper}`warning <https://example.org> {type=badge,color=warning}`
+{hyper}`info <https://example.org> {type=badge,color=info}`
+{hyper}`light <https://example.org> {type=badge,color=light}`
+{hyper}`dark <https://example.org> {type=badge,color=dark}`
+{hyper}`muted <https://example.org> {type=badge,color=muted}`
+
+{hyper}`primary <https://example.org> {type=badge,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=badge,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=badge,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=badge,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=badge,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=badge,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=badge,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=badge,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=badge,color=muted,outline=true}`
+:::
+
+::::
+
+
+::::{dropdown} Buttons Everywhere
+:animate: fade-in-slide-down
+:open:
+
+Buttons in multiple colors, optionally outlined.
+
+{hyper}`primary <https://example.org> {type=button,color=primary}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary}`
+{hyper}`success <https://example.org> {type=button,color=success}`
+{hyper}`danger <https://example.org> {type=button,color=danger}`
+{hyper}`warning <https://example.org> {type=button,color=warning}`
+{hyper}`info <https://example.org> {type=button,color=info}`
+{hyper}`light <https://example.org> {type=button,color=light}`
+{hyper}`dark <https://example.org> {type=button,color=dark}`
+{hyper}`muted <https://example.org> {type=button,color=muted}`
+
+{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
+
+:::{code} markdown
+
+{hyper}`primary <https://example.org> {type=button,color=primary}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary}`
+{hyper}`success <https://example.org> {type=button,color=success}`
+{hyper}`danger <https://example.org> {type=button,color=danger}`
+{hyper}`warning <https://example.org> {type=button,color=warning}`
+{hyper}`info <https://example.org> {type=button,color=info}`
+{hyper}`light <https://example.org> {type=button,color=light}`
+{hyper}`dark <https://example.org> {type=button,color=dark}`
+{hyper}`muted <https://example.org> {type=button,color=muted}`
+
+{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
+:::
+
+::::
+
 
 ::::{dropdown} Shield Shortcuts
 :animate: fade-in-slide-down
@@ -723,7 +1035,7 @@ A few more examples, about shortcuts and intersphinx linking.
 
 Shield shortcut roles help saving a few keystrokes. Examples:
 `hyper-navigate`, `hyper-open`, `hyper-tutorial`, `hyper-read-more`,
-`hyper-readme-github`, `hyper-nb-colab`, `hyper-nb-binder`, `hyper-nb-github`. 
+`hyper-readme-github`, `hyper-nb-colab`, `hyper-nb-binder`, `hyper-nb-github`.
 
 ---
 
@@ -751,59 +1063,6 @@ Shield shortcut roles help saving a few keystrokes. Examples:
 {hyper-nb-binder}`https://example.org`
 {hyper-nb-github}`https://example.org`
 :::
-::::
-
-
-::::{dropdown} Buttons Everywhere
-:animate: fade-in-slide-down
-:open:
-
-Buttons in multiple colors, optionally outlined. \
-Colors: primary, secondary, success, danger, warning, info, light, dark, muted
-
-{hyper}`primary <https://example.org> {type=button,color=primary}`
-{hyper}`secondary <https://example.org> {type=button,color=secondary}`
-{hyper}`success <https://example.org> {type=button,color=success}`
-{hyper}`danger <https://example.org> {type=button,color=danger}`
-{hyper}`warning <https://example.org> {type=button,color=warning}`
-{hyper}`info <https://example.org> {type=button,color=info}`
-{hyper}`light <https://example.org> {type=button,color=light}`
-{hyper}`dark <https://example.org> {type=button,color=dark}`
-{hyper}`muted <https://example.org> {type=button,color=muted}`
-
-{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
-{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
-{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
-{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
-{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
-{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
-{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
-{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
-{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
-
-:::{code} markdown
-
-{hyper}`primary <https://example.org> {type=button,color=primary}`
-{hyper}`secondary <https://example.org> {type=button,color=secondary}`
-{hyper}`success <https://example.org> {type=button,color=success}`
-{hyper}`danger <https://example.org> {type=button,color=danger}`
-{hyper}`warning <https://example.org> {type=button,color=warning}`
-{hyper}`info <https://example.org> {type=button,color=info}`
-{hyper}`light <https://example.org> {type=button,color=light}`
-{hyper}`dark <https://example.org> {type=button,color=dark}`
-{hyper}`muted <https://example.org> {type=button,color=muted}`
-
-{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
-{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
-{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
-{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
-{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
-{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
-{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
-{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
-{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
-:::
-
 ::::
 
 

--- a/docs/hyper.md
+++ b/docs/hyper.md
@@ -52,6 +52,11 @@ linking capabilities.
     The {ref}`hyper-button` Hyper renders hyperlinks using the
     {ref}`button <sd:buttons>` directive from [](inv:sd#index).
 
+    :::{rubric} Card
+    :::
+    The {ref}`hyper-card` Hyper renders hyperlinks using the
+    {ref}`card <sd:sd-cards>` directive from [](inv:sd#index).
+
     :::{rubric} Shield
     :::
     A {ref}`hyper-shield`-typed Hyper renders hyperlinks using
@@ -71,6 +76,9 @@ defined using the markup outlined below.
 
 :Button:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
+
+:Card:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=card,short-title=true}`
 
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
@@ -293,14 +301,14 @@ A basic badge hyperlink for URLs, without any options.
 ::::::{sd-row}
 :::::{sd-item}
 {hyper}`shield-directive {type=badge}` \
-{hyper}`Shield badges <shield-directive> {type=badge}`
+{hyper}`Shield Badges <shield-directive> {type=badge}`
 :::::
 :::::{sd-item}
 Use project-local references.
 ::::{code} markdown
 
 {hyper}`shield-directive {type=badge}` \
-{hyper}`Shield badges <shield-directive> {type=badge}`
+{hyper}`Shield Badges <shield-directive> {type=badge}`
 ::::
 :::::
 ::::::
@@ -484,14 +492,14 @@ A basic button hyperlink for URLs, without any options.
 ::::::{sd-row}
 :::::{sd-item}
 {hyper}`shield-directive {type=button}` \
-{hyper}`Shield badges <shield-directive> {type=button}`
+{hyper}`Shield Badges <shield-directive> {type=button}`
 :::::
 :::::{sd-item}
 Use project-local references.
 ::::{code} markdown
 
 {hyper}`shield-directive {type=button}` \
-{hyper}`Shield badges <shield-directive> {type=button}`
+{hyper}`Shield Badges <shield-directive> {type=button}`
 ::::
 :::::
 ::::::
@@ -643,6 +651,152 @@ The value of the `icon` option translates to the syntax of an {ref}`inline icon
 
 {hyper}`Read More <https://example.org> {type=button,icon=octicon:report}` \
 {hyper}`Read More <https://example.org> {type=button,color=info,outline=true,icon=material-outlined:emoji_objects;3em;sd-text-primary}`
+::::
+:::::
+::::::
+
+
+:::::::
+
+
+(hyper-card)=
+### Card
+
+Adding the option `{type=card}` renders the hyperlink using a card based
+on the sphinx-design [`card`](inv:sd#cards) directive, it
+accepts the same options, and the additional `icon` option.
+
+:::{rubric} Options
+:::
+
+The `card` Hyper understands the same options like offered by the `card`
+directive, see [](inv:sd#cards:options).
+
+
+:::::::{sd-table}
+:widths: 3 9
+:row-class: col-compact bottom-margin-generous
+
+::::::{sd-row}
+:::::{sd-item} **Item**
+:::::
+:::::{sd-item} **Description and Syntax**
+:::::
+::::::
+
+:::{rubric} Fundamentals
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=card}`
+:::::
+:::::{sd-item}
+A basic card hyperlink for URLs, without any options.
+::::{code} markdown
+
+{hyper}`https://example.org {type=card}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`shield-directive {type=card}` \
+{hyper}`Shield Badges <shield-directive> {type=card}`
+:::::
+:::::{sd-item}
+Use project-local references.
+::::{code} markdown
+
+{hyper}`shield-directive {type=card}` \
+{hyper}`Shield Badges <shield-directive> {type=card}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`sd:sd-cards {type=card}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=card}`
+:::::
+:::::{sd-item}
+Use intersphinx references.
+::::{code} markdown
+
+{hyper}`sd:sd-cards {type=card}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=card}`
+::::
+:::::
+::::::
+
+
+
+:::{rubric} Title, Header, Footer
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=card,title=title,header=header,footer=footer}`
+:::::
+:::::{sd-item}
+The `title`, `header`, and `footer` options directly translate to the
+corresponding slots of the card element.
+::::{code} markdown
+
+{hyper}`https://example.org {type=card,title=title,header=header,footer=footer}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`content <https://example.org> {type=card}` \
+{hyper}`https://example.org {type=card,content=content}`
+:::::
+:::::{sd-item}
+The value of the link title / label can be defined on behalf of the {ref}
+syntax, as usual, or by using the `content` option.
+::::{code} markdown
+
+{hyper}`content <https://example.org> {type=card}` \
+{hyper}`https://example.org {type=card,content=content}`
+::::
+:::::
+::::::
+
+
+:::{rubric} Style
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=card,shadow=md}`
+:::::
+:::::{sd-item}
+Shadows.
+::::{code} markdown
+
+{hyper}`https://example.org {type=card,shadow=md}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=card,icon=octicon:rocket}` \
+{hyper}`https://example.org {type=card,icon=octicon:rocket;3em,notext=true,text-align=center}`
+:::::
+:::::{sd-item}
+Icons.
+::::{code} markdown
+
+{hyper}`https://example.org {type=card,icon=octicon:rocket}` \
+{hyper}`https://example.org {type=card,icon=octicon:rocket;3em,notext=true,text-align=center}`
 ::::
 :::::
 ::::::

--- a/docs/hyper.md
+++ b/docs/hyper.md
@@ -39,10 +39,19 @@ linking capabilities.
 
 :Layout and Style:
     Other than rendering plain HTML hyperlink anchors, the `hyper` role
-    provides an array of options to present hyperlinks differently.
-    For example, hyperlinks can be represented through badges from
-    [Shields.io], building upon the {ref}`shield <shield-directive>`
-    directive, just by slapping a `{type=shield}` option on it.
+    provides an array of options to present hyperlinks differently. Hyper
+    currently supports:
+
+    :::{rubric} Button
+    :::
+    The {ref}`hyper-button` Hyper renders hyperlinks using the
+    {ref}`button <sd:buttons>` directive from [](inv:sd#index).
+
+    :::{rubric} Shield
+    :::
+    A {ref}`hyper-shield`-typed Hyper renders hyperlinks using
+    badges from [Shields.io], building upon the {ref}`shield
+    <shield-directive>` directive from {ref}`index`.
 
 
 ## Synopsis
@@ -52,8 +61,11 @@ defined using the markup outlined below.
 
 ::::{card}
 
-:Text-Only:
+:Text:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+
+:Button:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
 
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
@@ -80,7 +92,7 @@ mimicking and expanding `{ref}`.
 
 :::::::{sd-table}
 :widths: 3 9
-:row-class: col-compact
+:row-class: col-compact bottom-margin-generous
 
 :::{rubric} Fundamentals
 :::
@@ -193,10 +205,10 @@ Indirect references are defined out-of-band from the link definition, for exampl
 at the end of the page.
 
 In MyST, indirect references are defined by, for example:
-- `[label]: <reference>`
-- `[label]: #<reference>`
-- `[label]: inv:<project>#<reference>`
-- `[label]: <url>`
+- `[label]: reference`
+- `[label]: #reference`
+- `[label]: inv:project#reference`
+- `[label]: url`
 :::{div} text-small
 **Note:** This only works in MyST.
 :::
@@ -220,15 +232,246 @@ In MyST, indirect references are defined by, for example:
 
 The `hyper` role provides a few rendering variants.
 
+
+(hyper-button)=
+### Button
+
+Adding the option `{type=button}` renders the hyperlink using a badge based
+on the sphinx-design [`button`](inv:sd#buttons) directive implementation, it
+accepts the same options, and the additional `icon` option.
+
+ref-type (`button-ref` only)
+: Type of reference to use; `any` (default), `ref`, `doc`, or `myst`
+
+color
+: Set the color of the button (background and font).
+  One of the semantic color names: `primary`, `secondary`, `success`, `danger`,
+  `warning`, `info`, `light`, `dark`, `muted`.
+  The default value is `primary`.
+
+outline
+: Display button in outlined color style variant. Use `outline=true`
+  to toggle that option.
+
+align
+: Align the button on the page; `left`, `right`, `center` or `justify`
+
+expand
+: Expand to fit parent width. Use `expand=true` to toggle that option.
+
+click-parent
+: Make parent container also clickable. Use `click-parent=true` to
+  toggle that option.
+
+tooltip
+: Add tooltip text, displayed when hovering over the link.
+
+icon
+: All [icon features](inv:sd#icons) of sphinx-design can be used. The icon,
+  when given, will be placed on the left hand side of the text. The micro syntax
+  to describe it is not much different from the original role notation, just note
+  the colon `:` separates icon family from icon name.
+  ```markdown
+  {octicon}`report;1em;sd-text-info`  # Original MyST
+  octicon:report;1em;sd-text-info     # Hyper inline variant
+  ```
+
+shadow
+: Add shadow CSS.
+
+class
+: Additional CSS classes.
+
+
 :::::::{sd-table}
 :widths: 3 9
-:row-class: col-compact
+:row-class: col-compact bottom-margin-generous
 
-:::{rubric} Shield
+::::::{sd-row}
+:::::{sd-item} **Item**
+:::::
+:::::{sd-item} **Description and Syntax**
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=button}` \
+{hyper}`Read More <https://example.org> {type=button}`
+:::::
+:::::{sd-item}
+A basic button hyperlink for URLs, without any options.
+::::{code} markdown
+
+{hyper}`https://example.org {type=button}` \
+{hyper}`Read More <https://example.org> {type=button}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`shield-directive {type=button}` \
+{hyper}`Shield badges <shield-directive> {type=button}`
+:::::
+:::::{sd-item}
+Use project-local references.
+::::{code} markdown
+
+{hyper}`shield-directive {type=button}` \
+{hyper}`Shield badges <shield-directive> {type=button}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`sd:sd-cards {type=button}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=button}`
+:::::
+:::::{sd-item}
+Use intersphinx references.
+::::{code} markdown
+
+{hyper}`sd:sd-cards {type=button}` \
+{hyper}`Card Layouts <sd:sd-cards> {type=button}`
+::::
+:::::
+::::::
+
+
+:::{rubric} Layout
 :::
+
+::::::{sd-row}
+:::::{sd-item}
+`expand` option.
+:::::
+:::::{sd-item}
+Use the `expand` option to fit the element to the width of its parent.
+{hyper}`https://example.org {type=button,expand=true}`
+::::{code} markdown
+
+{hyper}`https://example.org {type=button,expand=true}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+`align` option.
+:::::
+:::::{sd-item}
+Use the `align` option.
+
+{hyper}`https://example.org {type=button,align=center}`
+::::{code} markdown
+
+{hyper}`https://example.org {type=button,align=center}`
+::::
+:::{todo}
+:class: no-margin
+Apparently, the `align` option does not work?
+:::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+:::::
+:::::{sd-item}
+Because `hyper` roles render as inline elements, multiple instances can
+be placed side by side, even when written down spanning multiple lines.
+Regular button directives are block level elements, which would cause
+line breaks.
+::::{code} markdown
+
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+{hyper}`https://example.org {type=button,icon=octicon:rocket,notext=true}`
+::::
+:::::
+::::::
+
+
+:::{rubric} Style
+:::
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=button,outline=true}` \
+{hyper}`https://example.org {type=button,color=info}` \
+{hyper}`https://example.org {type=button,shadow=true}`
+:::::
+:::::{sd-item}
+Use `outline`, `color`, and `shadow` options.
+::::{code} markdown
+
+{hyper}`https://example.org {type=button,outline=true}` \
+{hyper}`https://example.org {type=button,color=info}` \
+{hyper}`https://example.org {type=button,shadow=true}`
+::::
+:::{todo}
+:class: no-margin
+Apparently, the `shadow` option does not work?
+:::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`https://example.org {type=button,class=text-small}` \
+{hyper}`https://example.org {type=button,tooltip=Tooltip Message}`
+:::::
+:::::{sd-item}
+Use `class` and `tooltip` options.
+::::{code} markdown
+
+{hyper}`https://example.org {type=button,class=text-small}` \
+{hyper}`https://example.org {type=button,tooltip=Tooltip Message}`
+::::
+:::::
+::::::
+
+
+::::::{sd-row}
+:::::{sd-item}
+{hyper}`Read More <https://example.org> {type=button,icon=octicon:report}` \
+{hyper}`Read More <https://example.org> {type=button,color=info,outline=true,icon=material-outlined:emoji_objects;3em;sd-text-primary}`
+:::::
+:::::{sd-item}
+The value of the `icon` option translates to the syntax of an {ref}`inline icon
+<sd:icons>` from [](inv:sd#index), inheriting all its features.
+::::{code} markdown
+
+{hyper}`Read More <https://example.org> {type=button,icon=octicon:report}` \
+{hyper}`Read More <https://example.org> {type=button,color=info,outline=true,icon=material-outlined:emoji_objects;3em;sd-text-primary}`
+::::
+:::::
+::::::
+
+
+:::::::
+
+
+(hyper-shield)=
+### Shield
 
 Adding the option `{type=shield}` renders the hyperlink using a badge based
 on the [`shield`](#shield-directive) directive implementation.
+
+:::::::{sd-table}
+:widths: 3 9
+:row-class: col-compact bottom-margin-generous
 
 ::::::{sd-row}
 :::::{sd-item} **Item**
@@ -318,6 +561,9 @@ MyST reference syntax is also supported for intersphinx links.
 ::::::
 
 
+:::{rubric} Layout
+:::
+
 ::::::{sd-row}
 :::::{sd-item}
 {hyper}`https://example.org {type=shield,label=Read}`
@@ -370,8 +616,8 @@ Text input also accepts Unicode glyphs.
 {hyper}`H2 <https://example.org> {type=shield}`
 :::::
 :::::{sd-item}
-By default, `hyper` roles render as inline elements, so multiple ones are
-placed side by side, even when authored using line breaks.
+Because `hyper` roles render as inline elements, multiple instances can
+be placed side by side, even when written down spanning multiple lines.
 ::::{code} markdown
 
 {hyper}`H1 <https://example.org> {type=shield}`
@@ -385,7 +631,7 @@ continuation character.
 ::::::
 
 
-:::{rubric} Styling
+:::{rubric} Style
 :::
 
 About defining colors, an icon, and the style/shape of the shield.
@@ -463,19 +709,19 @@ The [`style`](#shield-style) option determines the style / shape of the shield.
 :::::
 ::::::
 
-
 :::::::
+
 
 
 ## Gallery
 
 A few more examples, about shortcuts and intersphinx linking.
 
-::::{dropdown} Shortcuts
+::::{dropdown} Shield Shortcuts
 :animate: fade-in-slide-down
 :open:
 
-Shortcut roles help saving keystrokes. Examples:
+Shield shortcut roles help saving a few keystrokes. Examples:
 `hyper-navigate`, `hyper-open`, `hyper-tutorial`, `hyper-read-more`,
 `hyper-readme-github`, `hyper-nb-colab`, `hyper-nb-binder`, `hyper-nb-github`. 
 
@@ -492,7 +738,7 @@ Shortcut roles help saving keystrokes. Examples:
 {hyper-nb-binder}`https://example.org`
 {hyper-nb-github}`https://example.org`
 
-::::{code} markdown
+:::{code} markdown
 
 {hyper-navigate}`https://example.org`
 {hyper-open}`https://example.org`
@@ -504,7 +750,62 @@ Shortcut roles help saving keystrokes. Examples:
 {hyper-nb-colab}`https://example.org`
 {hyper-nb-binder}`https://example.org`
 {hyper-nb-github}`https://example.org`
+:::
 ::::
+
+
+::::{dropdown} Buttons Everywhere
+:animate: fade-in-slide-down
+:open:
+
+Buttons in multiple colors, optionally outlined. \
+Colors: primary, secondary, success, danger, warning, info, light, dark, muted
+
+{hyper}`primary <https://example.org> {type=button,color=primary}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary}`
+{hyper}`success <https://example.org> {type=button,color=success}`
+{hyper}`danger <https://example.org> {type=button,color=danger}`
+{hyper}`warning <https://example.org> {type=button,color=warning}`
+{hyper}`info <https://example.org> {type=button,color=info}`
+{hyper}`light <https://example.org> {type=button,color=light}`
+{hyper}`dark <https://example.org> {type=button,color=dark}`
+{hyper}`muted <https://example.org> {type=button,color=muted}`
+
+{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
+
+:::{code} markdown
+
+{hyper}`primary <https://example.org> {type=button,color=primary}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary}`
+{hyper}`success <https://example.org> {type=button,color=success}`
+{hyper}`danger <https://example.org> {type=button,color=danger}`
+{hyper}`warning <https://example.org> {type=button,color=warning}`
+{hyper}`info <https://example.org> {type=button,color=info}`
+{hyper}`light <https://example.org> {type=button,color=light}`
+{hyper}`dark <https://example.org> {type=button,color=dark}`
+{hyper}`muted <https://example.org> {type=button,color=muted}`
+
+{hyper}`primary <https://example.org> {type=button,color=primary,outline=true}`
+{hyper}`secondary <https://example.org> {type=button,color=secondary,outline=true}`
+{hyper}`success <https://example.org> {type=button,color=success,outline=true}`
+{hyper}`danger <https://example.org> {type=button,color=danger,outline=true}`
+{hyper}`warning <https://example.org> {type=button,color=warning,outline=true}`
+{hyper}`info <https://example.org> {type=button,color=info,outline=true}`
+{hyper}`light <https://example.org> {type=button,color=light,outline=true}`
+{hyper}`dark <https://example.org> {type=button,color=dark,outline=true}`
+{hyper}`muted <https://example.org> {type=button,color=muted,outline=true}`
+:::
+
+::::
+
 
 ::::{dropdown} Intersphinx across the board
 :animate: fade-in-slide-down
@@ -554,7 +855,8 @@ There are some flaws here yet, see backlog below.
 
 :::{todo}
 There are a few errors in here: `sd:index`, `sd:badges_buttons`, and
-`doc:badges_buttons` can't be resolved well.
+`doc:badges_buttons` can't be resolved well. See "Intersphinx across
+the board".
 :::
 :::{todo}
 Link label resolution does not work yet with project-local links, e.g.

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ shield
 :caption: Roles
 :hidden:
 
+hyper
 tag
 ```
 
@@ -124,6 +125,13 @@ Composite info card container element, to be used as a grid item.
 :link-type: doc
 
 Badge generator for Shields\.io, with optional target linking.
+:::
+
+:::{grid-item-card} {octicon}`shield` Hyper
+:link: hyper
+:link-type: doc
+
+A versatile hyperlink generator.
 :::
 
 :::{grid-item-card} {octicon}`tag` Special badges

--- a/docs/shield.md
+++ b/docs/shield.md
@@ -9,7 +9,8 @@ A component to render badges through [Shields.io], with or without links,
 and optional parameterization. It implements the Sphinx directive `shield`.
 
 
-## Details
+(shield-options)=
+## Options
 
 The `shield` directive supports the options provided by [Shields.io Static Badges].
 
@@ -644,7 +645,17 @@ In MyST, indirect references are defined by, for example:
 :::::::
 
 
+## Backlog
+
+:::{todo}
+Provide style presets, like the shortcut `hyper` roles, or how
+[markdown-badges] defines them.
+:::
+
+
+
 [icon slugs]: https://github.com/simple-icons/simple-icons/blob/master/slugs.md
+[markdown-badges]: https://github.com/Ileriayo/markdown-badges
 [Shields.io]: https://shields.io/
 [Shields.io Logos]: https://shields.io/docs/logos
 [Shields.io Static Badges]: https://shields.io/badges/static-badge

--- a/docs/snippets/myst/hyper.md
+++ b/docs/snippets/myst/hyper.md
@@ -1,5 +1,8 @@
-:Text-Only:
+:Text:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+
+:Button:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
 
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`

--- a/docs/snippets/myst/hyper.md
+++ b/docs/snippets/myst/hyper.md
@@ -1,0 +1,5 @@
+:Text-Only:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+
+:Shield:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`

--- a/docs/snippets/myst/hyper.md
+++ b/docs/snippets/myst/hyper.md
@@ -1,8 +1,11 @@
-:Text:
-    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`
+:Badge:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=badge,outline=true,short-title=true}`
 
 :Button:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
 
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
+
+:Text:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {short-title=true}`

--- a/docs/snippets/myst/hyper.md
+++ b/docs/snippets/myst/hyper.md
@@ -4,6 +4,9 @@
 :Button:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=button,outline=true,short-title=true}`
 
+:Card:
+    {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=card,short-title=true}`
+
 :Shield:
     {hyper}`https://community.panodata.org/t/technical-advancements-in-sphinx/278 {type=shield,label=Navigate to,short-title=true}`
 

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,6 +1,6 @@
 (tag-role)=
 
-# `tag(s)` role
+# Tag
 
 
 ## About

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ test = [
   "pytest<9",
   "pytest-cov<6",
   "pytest-regressions<3",
+  "sphinx_pytest<0.3",
 ]
 [project.urls]
 changelog = "https://github.com/panodata/sphinx-design-elements/blob/main/CHANGES.md"

--- a/sphinx_design_elements/compiled/style.css
+++ b/sphinx_design_elements/compiled/style.css
@@ -10,6 +10,11 @@
   display: inline;
 }
 
+hr.docutils {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
 /* Very small text size */
 .text-small {
   font-size: small;

--- a/sphinx_design_elements/compiled/style.css
+++ b/sphinx_design_elements/compiled/style.css
@@ -10,6 +10,11 @@
   display: inline;
 }
 
+/* No borders */
+.no-margin {
+  margin: 0;
+}
+
 hr.docutils {
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
@@ -78,4 +83,8 @@ hr.docutils {
 .sd-col > div.line-block {
   margin-top: unset;
   margin-bottom: unset;
+}
+
+.bottom-margin-generous {
+  margin-bottom: 2em !important;
 }

--- a/sphinx_design_elements/extension.py
+++ b/sphinx_design_elements/extension.py
@@ -10,6 +10,7 @@ from sphinx_design.extension import depart_container, visit_container
 from . import compiled as static_module
 from .dropdown_group import setup_dropdown_group
 from .gridtable import setup_gridtable
+from .hyper import setup_hyper
 from .infocard import setup_infocard
 from .shield import setup_shield
 from .tag import setup_tags
@@ -29,6 +30,7 @@ def setup_extension(app: Sphinx) -> None:
 
     setup_dropdown_group(app)
     setup_gridtable(app)
+    setup_hyper(app)
     setup_infocard(app)
     setup_shield(app)
     setup_tags(app)

--- a/sphinx_design_elements/hyper.py
+++ b/sphinx_design_elements/hyper.py
@@ -1,0 +1,292 @@
+import re
+from typing import Any, Dict, List, Tuple, Union
+from unittest.mock import patch
+from urllib.parse import parse_qs
+
+import yaml
+from docutils import nodes
+from docutils.nodes import Node, system_message, unescape
+from docutils.parsers.rst.states import Inliner
+from myst_parser.mocking import MockInliner
+from sphinx.application import Sphinx
+from sphinx.roles import AnyXRefRole
+from sphinx.util.docutils import SphinxRole
+
+from sphinx_design_elements.util.directive import SmartReference
+from sphinx_design_elements.util.role import (
+    get_html_page_title,
+    label_from_reference_element,
+    link_type,
+    parse_block_myst,
+    parse_block_rst,
+    resolve_reference,
+)
+
+
+def setup_hyper(app: Sphinx):
+    """
+    Set up the `hyper` shortcut role.
+    """
+    p = patch("myst_parser.mocking.MockInliner.parse_block", parse_block_myst, create=True)
+    p.start()
+    p2 = patch("docutils.parsers.rst.states.Inliner.parse_block", parse_block_rst, create=True)
+    p2.start()
+    app.add_role("hyper", HyperRefRole(app=app))
+    app.add_role("hyper-navigate", HyperNavigateRole(app=app))
+    app.add_role("hyper-open", HyperOpenRole(app=app))
+    app.add_role("hyper-tutorial", HyperTutorialRole(app=app))
+    app.add_role("hyper-read-more", HyperReadMoreRole(app=app))
+    app.add_role("hyper-readme-github", HyperReadmeGitHubRole(app=app))
+    app.add_role("hyper-nb-colab", HyperNotebookColabRole(app=app))
+    app.add_role("hyper-nb-binder", HyperNotebookBinderRole(app=app))
+    app.add_role("hyper-nb-github", HyperNotebookGitHubRole(app=app))
+
+
+class HyperRefRole(AnyXRefRole):
+    """
+    Craft hyperlinks with style.
+
+    Synopsis:
+
+    {hyper}`Navigate to Tutorial <fts-analyzer> {type=shield,color=darkcyan,logo=Markdown}`
+    """
+
+    special_types = ["shield"]
+
+    options_re = re.compile(r"^(?P<target>.+?)\s*(?:{(?P<options>.+)})?$", re.DOTALL)
+    title_and_options_re = re.compile(
+        r"^(?P<title>.+?)\s*(?<!\x00)<(?P<target>.+?)>(?:\s*{(?P<options>.+)})?$", re.DOTALL
+    )
+
+    default_options: Dict[str, str] = {}
+
+    def __init__(self, app: Sphinx, *args, **kwargs):
+        # Any number of options for the reference role.
+        self.ref_options: Dict[str, Any] = {}
+        self.system_messages: List[nodes.system_message] = []
+        self.app = app
+        super().__init__(*args, **kwargs)
+
+    def __call__(
+        self,
+        name: str,
+        rawtext: str,
+        text: str,
+        lineno: int,
+        inliner: Union[Inliner, MockInliner],
+        options: Union[Dict, None] = None,
+        content: Union[List[str], None] = None,
+    ) -> Tuple[List[Node], List[system_message]]:
+
+        self.rawtext = rawtext
+        self.text = unescape(text)
+        self.lineno = lineno
+        self.inliner = inliner  # type: ignore[assignment]
+        # self.options = options  # noqa: ERA001
+        # self.content = content  # noqa: ERA001
+
+        options = options or {}
+        content = content or []
+
+        # if the first character is a bang, don't cross-reference at all
+        self.disabled = text.startswith("!")
+
+        self.title = ""
+        self.target = ""
+        self.ref_options = {}
+        if self.default_options:
+            self.ref_options.update(self.default_options)
+
+        matched = self.title_and_options_re.match(text)
+        if matched:
+            self.has_explicit_title = True
+        else:
+            self.has_explicit_title = False
+            matched = self.options_re.match(text)
+
+        if matched:
+            data = matched.groupdict()
+            for key, value in data.items():
+                if value is not None:
+                    data[key] = unescape(value)
+            if data["options"]:
+                self.ref_options.update(decode_hyper_options(data["options"]))
+            title = data.get("title")
+            target = data.get("target")
+
+            if target:
+                self.target = target
+            if title:
+                self.title = title
+
+            self.srh = SmartReference(ref=self.target)
+
+            # When no title is given, attempt to resolve it from the reference.
+            if not self.title:
+                try:
+                    label = self.resolve_page_title()
+                except ReferenceError:
+                    label = None
+                if label:
+                    self.title = label
+
+        else:
+            error = ValueError("Unable to resolve reference")
+            msg = inliner.reporter.warning(error)  # type: ignore[union-attr]
+            prb = inliner.problematic(rawtext, rawtext, msg)  # type: ignore[union-attr]
+            return [prb], [msg]
+
+        return SphinxRole.__call__(self, name, rawtext, text, lineno, inliner, options, content)  # type: ignore[arg-type]
+
+    def resolve_page_title(self) -> str:
+        """
+        Resolve page title from reference or URL.
+        """
+        ref: Union[nodes.Node, nodes.Element, None] = None
+        if self.srh.is_url():
+            try:
+                return get_html_page_title(self.target)
+            except Exception:
+                return self.target
+        elif self.srh.is_traditional_intersphinx_reference():
+            document = self.inliner.document  # type: ignore[attr-defined]
+            ref = resolve_reference(env=self.app.env, document=document, target=self.target)
+        elif self.srh.is_myst_reference():
+            link = f"[]({self.target})"
+            ref = self.render_snippet(link)[0][0]
+        if ref is not None:
+            return label_from_reference_element(ref)
+        return self.target
+
+    def run(self) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+        """Run the role."""
+
+        if self.title and "short-title" in self.ref_options:
+            del self.ref_options["short-title"]
+            self.title = self.title.split(" - ", 1)[0]
+
+        if not self.ref_options:
+            title = self.target
+            if self.title:
+                title = self.title
+            if self.srh.is_url() or self.srh.is_myst_reference():
+                snippet = f"[{title}]({self.target})"
+            elif self.srh.is_indirect_reference():
+                title = title.strip("[]")
+                snippet = f"[{title}]{self.target}"
+            else:
+                if self.title:
+                    snippet = f"{{ref}}`{self.title}<{self.target}>`"
+                else:
+                    snippet = f"{{ref}}`{self.target}`"
+            return self.render_snippet(snippet)
+
+        type_ = self.ref_options.get("type")
+        if type_ not in self.special_types:
+            raise NotImplementedError(
+                f"Hyperref type not implemented: {type_}." f"Viable choices: {self.special_types}"
+            )
+        del self.ref_options["type"]
+
+        if not self.ref_options.get("message"):
+            self.ref_options["message"] = self.title or self.target
+
+        tpl = {
+            "title": self.title,
+            "target": self.target,
+        }
+        if message := self.ref_options.get("message"):
+            message = message % tpl
+            self.ref_options["message"] = message
+        if label := self.ref_options.get("label"):
+            label = label % tpl
+            self.ref_options["label"] = label
+
+        if not self.ref_options.get("link"):
+            self.ref_options["link"] = self.target
+        if not self.ref_options.get("link-type"):
+            self.ref_options["link-type"] = link_type(self.ref_options.get("link"))
+        if not self.ref_options.get("link-title"):
+            self.ref_options["link-title"] = self.ref_options["message"]
+
+        snippet = f"""
+:::{{shield}}
+{self.directive_options}
+:::""".strip()
+
+        return self.render_snippet(snippet)
+
+    def render_snippet(self, snippet: str) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+        """
+        Render a MyST snippet.
+        """
+        directive_nodes, _ = self.inliner.parse_block(  # type: ignore[attr-defined]
+            text=snippet, lineno=self.lineno, memo=self, parent=self.inliner.parent  # type: ignore[attr-defined]
+        )
+        if not directive_nodes:
+            return [], self.system_messages
+        node = directive_nodes[0]
+        self.set_source_info(node)
+        return [node], self.system_messages
+
+    @property
+    def directive_options(self) -> str:
+        """
+        Format options in MyST directive format, using YAML.
+        """
+        return "---\n" + yaml.dump(self.ref_options)
+
+
+def decode_hyper_options(text: str) -> Dict[str, str]:
+    """
+    Decode options in {} from `{hyper}` roles.
+
+    {hyper}`Navigate to Tutorial <fts-analyzer> {type=shield,color=darkcyan,logo=Markdown}`
+    """
+    indata = parse_qs(text, separator=",")
+    outdata = {}
+    for key, value in indata.items():
+        outdata[key] = value[0]
+    return outdata
+
+
+class HyperNavigateRole(HyperRefRole):
+    default_options = decode_hyper_options(
+        "type=shield,label=Navigate to,message=%(title)s,short-title=true,color=darkcyan"
+    )
+
+
+class HyperOpenRole(HyperRefRole):
+    default_options = decode_hyper_options("type=shield,label=Open,message=%(title)s,short-title=true,color=darkblue")
+
+
+class HyperTutorialRole(HyperRefRole):
+    default_options = decode_hyper_options(
+        "type=shield,label=Navigate to,message=Tutorial,color=darkcyan,logo=Markdown"
+    )
+
+
+class HyperReadMoreRole(HyperRefRole):
+    default_options = decode_hyper_options("type=shield,label=Read More,color=yellow,logo=Markdown")
+
+
+class HyperReadmeGitHubRole(HyperRefRole):
+    default_options = decode_hyper_options("type=shield,message=Open README,color=darkblue,logo=GitHub")
+
+
+class HyperNotebookColabRole(HyperRefRole):
+    default_options = decode_hyper_options(
+        "type=shield,label=Open,message=Notebook on Colab,color=blue,logo=Google Colab"
+    )
+
+
+class HyperNotebookBinderRole(HyperRefRole):
+    default_options = decode_hyper_options(
+        "type=shield,label=Open,message=Notebook on Binder,color=lightblue,logo=binder"
+    )
+
+
+class HyperNotebookGitHubRole(HyperRefRole):
+    default_options = decode_hyper_options(
+        "type=shield,label=Open,message=Notebook on GitHub,color=darkgreen,logo=GitHub"
+    )

--- a/sphinx_design_elements/util/role.py
+++ b/sphinx_design_elements/util/role.py
@@ -86,7 +86,7 @@ def get_html_page_title(url: str) -> str:
 
 
 def parse_block_myst(
-    self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element
+    self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element, with_container: bool = False
 ) -> tuple[list[nodes.Node], list[nodes.system_message]]:
     """
     Parse the text and return a list of nodes.
@@ -100,7 +100,10 @@ def parse_block_myst(
             self._renderer.nested_render_text(text, lineno, inline=False)
 
     # Extract the reference node from the container paragraph node.
-    ref = container.next_node().next_node()
+    if with_container:
+        ref = container.next_node()
+    else:
+        ref = container.next_node().next_node()
     return [ref], []
 
 

--- a/sphinx_design_elements/util/role.py
+++ b/sphinx_design_elements/util/role.py
@@ -1,0 +1,132 @@
+from functools import lru_cache
+from typing import Any, Optional, Union
+
+from docutils import nodes
+from myst_parser.mocking import MockInliner
+from sphinx import addnodes
+from sphinx.environment import BuildEnvironment
+from sphinx.ext.intersphinx import resolve_reference_detect_inventory
+
+
+def resolve_reference(
+    env: BuildEnvironment, document: nodes.document, target: str, label: Optional[str] = None, level: int = 2, **kwargs
+) -> nodes.Element:
+    """
+    Create node layout for a link to a Sphinx intersphinx reference.
+    """
+
+    refnode_content = nodes.TextElement(reftarget=target, reftype="any")
+    refnode_xref = addnodes.pending_xref(reftarget=target, reftype="any")
+
+    ref = resolve_reference_detect_inventory(
+        env=env,
+        node=refnode_xref,
+        contnode=refnode_content,
+    )
+    # TODO: Add option to handle unresolved intersphinx references gracefully.
+    if ref is None:
+        raise ReferenceError(f"Unable to resolve intersphinx reference: {target}")
+    refuri = ref["refuri"]
+    if label is None:
+        label = label_from_reference_element(ref)
+    return nodes.reference(refuri=refuri, text=label, internal=True, level=level, **kwargs)
+
+
+def label_from_reference_element(ref: nodes.Node) -> str:
+    """
+    Get link label from `nodes.reference` element.
+
+    <reference internal="True" level="2"
+        refuri="https://cratedb.com/docs/guide/domain/document/index.html#document">Document Store</reference>
+    <reference internal="False" reftitle="(in CrateDB: Guide vlatest)"
+        refuri="https://cratedb.com/docs/guide/domain/document/index.html#document"><TextElement>Document Store</TextElement></reference>
+    """  # noqa: E501
+
+    """
+    txt = ref.next_node(nodes.TextElement).next_node()
+    if txt:
+        txt = ref.next_node(nodes.TextElement)
+    if txt:
+        return txt.astext()
+    return ref.astext()
+    """
+
+    try:
+        txt = next(ref.findall(nodes.TextElement, include_self=False))
+    except StopIteration:
+        txt = ref.next_node(nodes.TextElement)
+    if txt:
+        return txt.astext()
+    return ref.astext()
+
+
+def link_type(link: Union[str, None]) -> Union[str, None]:
+    if link is None:
+        return None
+    elif link.startswith("http://") or link.startswith("https://"):
+        return "url"
+    else:
+        return "ref"
+
+
+@lru_cache(maxsize=8192)
+def get_html_page_title(url: str) -> str:
+    """
+    Retrieve HTML page via HTTP, and extract value of <title>TEXT</title>.
+    """
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return url
+
+    from urllib.request import urlopen
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(urlopen(url), "html.parser")  # noqa: S310
+    return soup.title and soup.title.get_text() or url
+
+
+def parse_block_myst(
+    self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element
+) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+    """
+    Parse the text and return a list of nodes.
+
+    Similar to `myst_parser.mocking.MockInliner.parse`, but uses
+    `inline=False` for rendering, and returns only the inner node.
+    """
+    with self._renderer.current_node_context(parent):
+        container = nodes.Element()
+        with self._renderer.current_node_context(container):
+            self._renderer.nested_render_text(text, lineno, inline=False)
+
+    # Extract the reference node from the container paragraph node.
+    ref = container.next_node().next_node()
+    return [ref], []
+
+
+def parse_block_rst(  # pragma: nocover
+    self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element
+) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+    """
+    mw = MarkdownWrapper()
+    res = mw.render(text)
+    return res, []
+
+    memo.reporter = self.reporter
+    memo.document = self.document
+    memo.language = self.language
+    memo2 = Struct(
+        document=self.document,
+        reporter=self.reporter,
+        language=self.language,
+        title_styles=[],
+        section_level=0,
+        section_bubble_up_kludge=False,
+        inliner=self)
+    return self.parse(text=text, lineno=lineno, memo=memo, parent=parent)
+    """
+
+    error = NotImplementedError("The `hyper` role does not work with reStructuredText yet")
+    msg = self.reporter.error(error)
+    prb = self.problematic(text, text, msg)
+    return [prb], [msg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,9 +92,9 @@ def sphinx_builder(tmp_path: Path, make_app, monkeypatch):
 def render(sphinx_builder: Callable[..., SphinxBuilder]):
     roles._roles.clear()
 
-    def do(content):
+    def do(content, with_container: bool = False):
         builder = sphinx_builder()
-        return render_reference_builder(builder, content)
+        return render_reference_builder(builder, content, with_container=with_container)
 
     return do
 
@@ -105,7 +105,7 @@ def clean_doctree(doctree, pop_doc_attrs=("translation_progress",)):
     return doctree
 
 
-def render_reference_builder(builder: SphinxBuilder, content: str):
+def render_reference_builder(builder: SphinxBuilder, content: str, with_container: bool = False):
     """Test snippets written in MyST Markdown (after post-transforms)."""
     from tests.test_snippets import write_assets
 
@@ -114,12 +114,17 @@ def render_reference_builder(builder: SphinxBuilder, content: str):
     write_assets(builder.src_path)
     builder.build()
 
-    text = find_reference(clean_doctree(builder.get_doctree("index", post_transforms=True))).pformat()
+    text = find_reference(
+        clean_doctree(builder.get_doctree("index", post_transforms=True)), with_container=with_container
+    ).pformat()
     return text
 
 
-def find_reference(node: nodes.Node):
-    results = list(node.findall(lambda _node: isinstance(_node, (nodes.reference, addnodes.pending_xref))))
+def find_reference(node: nodes.Node, with_container: bool = False):
+    constraint = (nodes.reference, addnodes.pending_xref)
+    if with_container:
+        constraint = (nodes.container,)
+    results = list(node.findall(lambda _node: isinstance(_node, constraint)))
     if results:
         return results[0]
     return node

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def render_reference_builder(builder: SphinxBuilder, content: str):
     """Test snippets written in MyST Markdown (after post-transforms)."""
     from tests.test_snippets import write_assets
 
+    builder.app.config.intersphinx_disabled_reftypes = []
     builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
     write_assets(builder.src_path)
     builder.build()

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -1,0 +1,147 @@
+import re
+
+import pytest
+from sphinx_pytest.plugin import CreateDoctree
+
+from tests.util import render_reference
+
+
+def test_hyper_http_url_valid(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`https://example.org`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<reference refuri="https://example.org">
+    Example Domain
+""".lstrip()
+    )
+
+
+def test_hyper_http_url_invalid(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`https://randomfoobarunknown.org`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<reference refuri="https://randomfoobarunknown.org">
+    https://randomfoobarunknown.org
+""".lstrip()
+    )
+
+
+def test_hyper_mailto_url(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`mailto:test@example.org`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<reference refuri="mailto:test@example.org">
+    mailto:test@example.org
+""".lstrip()
+    )
+
+
+def test_hyper_label_pending(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`foobar`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<pending_xref refdoc="index" refdomain="std" refexplicit="True" reftarget="foobar" reftype="ref" refwarn="True">
+    <inline classes="xref std std-ref">
+        foobar
+""".lstrip()
+    )
+
+
+def test_hyper_intersphinx(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`foo:bar`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="foo:bar" reftype="ref" refwarn="True">
+    <inline classes="xref std std-ref">
+        foo:bar
+""".lstrip()
+    )
+
+
+def test_hyper_myst(sphinx_doctree_no_tr: CreateDoctree):
+    content = "{hyper}`project:index.md`"
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<pending_xref refdoc="index" refdomain="doc" refexplicit="True" reftarget="index" reftargetid="True" reftype="myst">
+    <inline classes="xref myst">
+        project:index.md
+""".lstrip()
+    )
+
+
+def test_hyper_indirect(render):
+    content = """
+{hyper}`Example Domain <[foobar]>`
+
+[foobar]: https://example.org/
+"""
+    ptree = render(content)
+    assert (
+        ptree
+        == """
+<reference refuri="https://example.org/">
+    Example Domain
+""".lstrip()
+    )
+
+
+def test_hyper_explicit_title(sphinx_doctree_no_tr: CreateDoctree):
+    content = """
+(foobar)=
+{hyper}`title <foobar>`
+"""
+    ptree = render_reference(sphinx_doctree_no_tr, content)
+    assert (
+        ptree
+        == """
+<pending_xref refdoc="index" refdomain="std" refexplicit="True" reftarget="foobar" reftype="ref" refwarn="True">
+    <inline classes="xref std std-ref">
+        title
+""".lstrip()
+    )
+
+
+def test_hyper_shield_label(render):
+    content = """
+(foobar)=
+{hyper}`foobar {type=shield}`
+"""
+    assert (
+        render(content)
+        == """
+<reference id_link="True" refid="foobar" reftitle="foobar">
+    <image alt="foobar" candidates="{'?': 'https://img.shields.io/badge/foobar-blue'}" uri="https://img.shields.io/badge/foobar-blue">
+""".lstrip()
+    )
+
+
+def test_hyper_shield_open(render):
+    content = """
+(foobar)=
+{hyper-open}`foobar`
+"""
+    assert (
+        render(content)
+        == """
+<reference id_link="True" refid="foobar" reftitle="foobar">
+    <image alt="foobar" candidates="{'?': 'https://img.shields.io/badge/Open-foobar-darkblue'}" uri="https://img.shields.io/badge/Open-foobar-darkblue">
+""".lstrip()
+    )
+
+
+def test_hyper_unknown_type(render):
+    with pytest.raises(NotImplementedError) as ex:
+        render("{hyper}`foobar {type=foobar}`")
+    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['shield']"))

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -9,7 +9,9 @@ from tests.util import render_reference
 def test_hyper_unknown_type(render):
     with pytest.raises(NotImplementedError) as ex:
         render("{hyper}`foobar {type=foobar}`")
-    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['badge', 'button', 'shield']"))
+    assert ex.match(
+        re.escape("Hyperref type not implemented: foobar. Viable choices: ['badge', 'button', 'card', 'shield']")
+    )
 
 
 def test_hyper_http_url_valid(sphinx_doctree_no_tr: CreateDoctree):
@@ -198,4 +200,51 @@ def test_hyper_badge(render):
     <inline>
         Example Domain
 """.lstrip()
+    )
+
+
+def test_hyper_card_minimal(render):
+    content = """
+{hyper}`https://example.org {type=card}`
+"""
+    text = render(content, with_container=True)
+
+    assert (
+        text
+        == """
+<container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
+    <container classes="sd-card-body" design_component="card-body" is_div="True">
+        <paragraph classes="sd-card-text">
+            Example Domain
+    <PassthroughTextElement>
+        <reference classes="sd-stretched-link" refuri="https://example.org">
+""".lstrip()  # noqa: E501
+    )
+
+
+def test_hyper_card_full(render):
+    content = """
+{hyper}`https://example.org {type=card,title=title,header=header,footer=footer}`
+"""
+    text = render(content, with_container=True)
+
+    assert (
+        text
+        == """
+<container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
+    <container classes="sd-card-header" design_component="card-header" is_div="True">
+        <paragraph classes="sd-card-text">
+            header
+    <container classes="sd-card-body" design_component="card-body" is_div="True">
+        <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
+            <PassthroughTextElement>
+                title
+        <paragraph classes="sd-card-text">
+            Example Domain
+    <container classes="sd-card-footer" design_component="card-footer" is_div="True">
+        <paragraph classes="sd-card-text">
+            footer
+    <PassthroughTextElement>
+        <reference classes="sd-stretched-link" refuri="https://example.org">
+""".lstrip()  # noqa: E501
     )

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -9,7 +9,7 @@ from tests.util import render_reference
 def test_hyper_unknown_type(render):
     with pytest.raises(NotImplementedError) as ex:
         render("{hyper}`foobar {type=foobar}`")
-    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['button', 'shield']"))
+    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['badge', 'button', 'shield']"))
 
 
 def test_hyper_http_url_valid(sphinx_doctree_no_tr: CreateDoctree):
@@ -183,3 +183,19 @@ def test_hyper_button_icon_only(render):
     assert '<svg version="1.1"' in text
     assert "example.org" in text
     assert "Example Domain" not in text
+
+
+def test_hyper_badge(render):
+    content = """
+{hyper}`https://example.org {type=badge}`
+"""
+    text = render(content)
+
+    assert (
+        text
+        == """
+<reference classes="sd-sphinx-override sd-badge sd-bg-primary sd-bg-text-primary" refuri="https://example.org">
+    <inline>
+        Example Domain
+""".lstrip()
+    )

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -6,6 +6,12 @@ from sphinx_pytest.plugin import CreateDoctree
 from tests.util import render_reference
 
 
+def test_hyper_unknown_type(render):
+    with pytest.raises(NotImplementedError) as ex:
+        render("{hyper}`foobar {type=foobar}`")
+    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['button', 'shield']"))
+
+
 def test_hyper_http_url_valid(sphinx_doctree_no_tr: CreateDoctree):
     content = "{hyper}`https://example.org`"
     ptree = render_reference(sphinx_doctree_no_tr, content)
@@ -141,7 +147,39 @@ def test_hyper_shield_open(render):
     )
 
 
-def test_hyper_unknown_type(render):
-    with pytest.raises(NotImplementedError) as ex:
-        render("{hyper}`foobar {type=foobar}`")
-    assert ex.match(re.escape("Hyperref type not implemented: foobar.Viable choices: ['shield']"))
+def test_hyper_button_basic(render):
+    content = """
+{hyper}`https://example.org {type=button}`
+"""
+    assert (
+        render(content)
+        == """
+<reference classes="sd-sphinx-override sd-btn sd-text-wrap sd-btn-primary" refuri="https://example.org">
+    <inline>
+        Example Domain
+""".lstrip()
+    )
+
+
+def test_hyper_button_with_icon(render):
+    content = """
+{hyper}`https://example.org {type=button,icon=octicon:report}`
+"""
+    text = render(content)
+
+    assert '<raw format="html"' in text
+    assert '<svg version="1.1"' in text
+    assert "example.org" in text
+    assert "Example Domain" in text
+
+
+def test_hyper_button_icon_only(render):
+    content = """
+{hyper}`https://example.org {type=button,icon=octicon:report,notext=true}`
+"""
+    text = render(content)
+
+    assert '<raw format="html"' in text
+    assert '<svg version="1.1"' in text
+    assert "example.org" in text
+    assert "Example Domain" not in text

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -13,7 +13,7 @@ from typing import Callable
 
 import pytest
 
-from .conftest import SphinxBuilder
+from tests.conftest import SphinxBuilder
 
 SNIPPETS_PATH = Path(__file__).parent.parent / "docs" / "snippets"
 SNIPPETS_GLOB_RST = list((SNIPPETS_PATH / "rst").glob("[!_]*"))

--- a/tests/test_snippets/snippet_myst_post_hyper.xml
+++ b/tests/test_snippets/snippet_myst_post_hyper.xml
@@ -3,10 +3,16 @@
         <title>
             Heading
         <paragraph>
-            :Text-Only:
+            :Text:
             
             <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
                 Technical advancements in Sphinx
+        <paragraph>
+            :Button:
+            
+            <reference classes="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <inline>
+                    Technical advancements in Sphinx
         <paragraph>
             :Shield:
             

--- a/tests/test_snippets/snippet_myst_post_hyper.xml
+++ b/tests/test_snippets/snippet_myst_post_hyper.xml
@@ -15,6 +15,15 @@
                 <inline>
                     Technical advancements in Sphinx
         <paragraph>
+            :Card:
+            
+            <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
+                <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Technical advancements in Sphinx
+                <PassthroughTextElement>
+                    <reference classes="sd-stretched-link" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+        <paragraph>
             :Shield:
             
             <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">

--- a/tests/test_snippets/snippet_myst_post_hyper.xml
+++ b/tests/test_snippets/snippet_myst_post_hyper.xml
@@ -3,10 +3,11 @@
         <title>
             Heading
         <paragraph>
-            :Text:
+            :Badge:
             
-            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
-                Technical advancements in Sphinx
+            <reference classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <inline>
+                    Technical advancements in Sphinx
         <paragraph>
             :Button:
             
@@ -18,3 +19,8 @@
             
             <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
                 <image alt="Technical advancements in Sphinx" candidates="{'?': 'https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue'}" uri="https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue">
+        <paragraph>
+            :Text:
+            
+            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                Technical advancements in Sphinx

--- a/tests/test_snippets/snippet_myst_post_hyper.xml
+++ b/tests/test_snippets/snippet_myst_post_hyper.xml
@@ -1,0 +1,14 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            :Text-Only:
+            
+            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                Technical advancements in Sphinx
+        <paragraph>
+            :Shield:
+            
+            <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <image alt="Technical advancements in Sphinx" candidates="{'?': 'https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue'}" uri="https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue">

--- a/tests/test_snippets/snippet_myst_pre_hyper.xml
+++ b/tests/test_snippets/snippet_myst_pre_hyper.xml
@@ -3,10 +3,16 @@
         <title>
             Heading
         <paragraph>
-            :Text-Only:
+            :Text:
             
             <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
                 Technical advancements in Sphinx
+        <paragraph>
+            :Button:
+            
+            <reference classes="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <inline>
+                    Technical advancements in Sphinx
         <paragraph>
             :Shield:
             

--- a/tests/test_snippets/snippet_myst_pre_hyper.xml
+++ b/tests/test_snippets/snippet_myst_pre_hyper.xml
@@ -15,6 +15,15 @@
                 <inline>
                     Technical advancements in Sphinx
         <paragraph>
+            :Card:
+            
+            <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
+                <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Technical advancements in Sphinx
+                <PassthroughTextElement>
+                    <reference classes="sd-stretched-link" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+        <paragraph>
             :Shield:
             
             <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">

--- a/tests/test_snippets/snippet_myst_pre_hyper.xml
+++ b/tests/test_snippets/snippet_myst_pre_hyper.xml
@@ -3,10 +3,11 @@
         <title>
             Heading
         <paragraph>
-            :Text:
+            :Badge:
             
-            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
-                Technical advancements in Sphinx
+            <reference classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <inline>
+                    Technical advancements in Sphinx
         <paragraph>
             :Button:
             
@@ -18,3 +19,8 @@
             
             <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
                 <image alt="Technical advancements in Sphinx" candidates="{'?': 'https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue'}" uri="https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue">
+        <paragraph>
+            :Text:
+            
+            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                Technical advancements in Sphinx

--- a/tests/test_snippets/snippet_myst_pre_hyper.xml
+++ b/tests/test_snippets/snippet_myst_pre_hyper.xml
@@ -1,0 +1,14 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            :Text-Only:
+            
+            <reference refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                Technical advancements in Sphinx
+        <paragraph>
+            :Shield:
+            
+            <reference reftitle="Technical advancements in Sphinx" refuri="https://community.panodata.org/t/technical-advancements-in-sphinx/278">
+                <image alt="Technical advancements in Sphinx" candidates="{'?': 'https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue'}" uri="https://img.shields.io/badge/Navigate%20to-Technical%20advancements%20in%20Sphinx-blue">

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,83 @@
+import os
+from unittest.mock import patch
+
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.errors import SphinxError
+from sphinx.testing.util import SphinxTestApp
+from sphinx_pytest.plugin import AppWrapper, CreateDoctree
+
+from sphinx_design_elements.hyper import setup_hyper
+from tests.conftest import SphinxBuilder
+from tests.test_snippets import write_assets
+
+
+class HyperTestApp(SphinxTestApp):
+    def __init__(self, *args, **kwargs):
+        setup_rformat()
+        setup_hyper(app=self)
+        super().__init__(*args, **kwargs)
+        self.config.intersphinx_disabled_reftypes = []
+
+
+def setup_rformat():
+    p = patch("sphinx_pytest.plugin.AppWrapper.rformat", rformat, create=True)
+    p.start()
+
+
+def rformat(self: AppWrapper, docname: str = "index", pop_doc_attrs=("translation_progress",)) -> str:
+    """
+    Return an indented pseudo-XML representation of a reference node.
+
+    It is similar to `pformat`, but does not return a document, but
+    a nested child node instead.
+    """
+    doctree = self.doctrees[docname].deepcopy()
+
+    # Extract reference node.
+    results = list(doctree.findall(lambda node: isinstance(node, (nodes.reference, addnodes.pending_xref))))
+    if not results:
+        text = doctree.pformat().replace(str(self._app.srcdir) + os.sep, "<src>/").rstrip()
+        raise SphinxError(f"Rendering failed: {text}")
+
+    doctree = results[0]
+
+    for attr_name in pop_doc_attrs:
+        doctree.attributes.pop(attr_name, None)
+    text = doctree.pformat()
+    return text
+
+
+def find_reference(node: nodes.Node) -> nodes.Node:
+    results = list(node.findall(lambda _node: isinstance(_node, (nodes.reference, addnodes.pending_xref))))
+    if results:
+        return results[0]
+    return node
+
+
+def clean_doctree(doctree, pop_doc_attrs=("translation_progress",)):
+    for attr_name in pop_doc_attrs:
+        doctree.attributes.pop(attr_name, None)
+    return doctree
+
+
+def render_reference(doctree: CreateDoctree, content: str) -> str:
+    doctree._app_cls = HyperTestApp
+    doctree.set_conf(
+        {"extensions": ["myst_parser"]},
+        # {"extensions": ["myst_parser"], "myst_enable_extensions": ["dollarmath"]}  # noqa: ERA001
+    )
+    result = doctree(content, "index.md")
+    payload = result.rformat()
+    result.app.cleanup()
+    return payload
+
+
+def render_reference_builder(builder: SphinxBuilder, content: str) -> str:
+    """Test snippets written in MyST Markdown (after post-transforms)."""
+
+    builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
+    write_assets(builder.src_path)
+    builder.build()
+
+    return find_reference(clean_doctree(builder.get_doctree("index", post_transforms=True))).pformat()


### PR DESCRIPTION
## About
An element to render hyperlinks, based on foundational components coming from sphinx{design}. It implements the Sphinx role `hyper`.

## Preview
https://sphinx-design-elements--71.org.readthedocs.build/en/71/hyper.html

## Details
- The `hyper` role builds upon and extends the semantics and implementation of the `ref`/`xref` roles/machinery.
- It is based on the components `badge`, `button`, `card`, and `shield`.
  - [Badges], [Buttons], and [Cards] are from [sphinx{design}](https://sphinx-design.readthedocs.io/).
  - Shields are from [Shields.io](https://shields.io/), unlocked per GH-69.
- Currently, it exclusively compiles to MyST Markdown. reStructuredText is not supported yet, and support will only be added based on community interest, if possible at all.

[Badges]: https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html#badges
[Buttons]: https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html#buttons
[Cards]: https://sphinx-design.readthedocs.io/en/latest/cards.html

## Usage
### Markdown
```markdown
{hyper}`https://example.org`
```

### reStructuredText
```rst
:hyper:`https://example.org`
```

## References
- [MEP 0002 - Cross Reference Simplifications using Markdown Links](https://mep.mystmd.org/en/latest/meps/mep-0002/)
- [Make intersphinx (a.k.a. external references) more user friendly](https://github.com/orgs/sphinx-doc/discussions/12152)
- https://github.com/sphinx-doc/sphinx/pull/12190
